### PR TITLE
Make max upload size configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,5 @@
 ## Settings fur running in docker compose.
 DATABASE_URL=postgresql://postgres:${POSTGRES_PASSWORD}@db:5432/bandbridge
 AUDIO_SERVICE_URL=http://audio:4001
+# MAX_UPLOAD_SIZE controls upload file size limit. Examples: 1GB, 500MB, 0.5GB, 100kB
+MAX_UPLOAD_SIZE=1GB

--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@ All audio and waveform file requests from the frontend are proxied through the N
 - `NEXT_PUBLIC_BAND_NAME`: The band name shown in the UI.
 - `AUDIO_SERVICE_PORT`: Port for the audio microservice (default: 4001, internal only).
 - `AUDIO_SERVICE_URL`: URL for the audio microservice (used by the Next.js API to proxy requests).
+- `MAX_UPLOAD_SIZE`: Maximum allowed file upload size for the audio microservice. Accepts human readable values like `1GB`, `500MB`, `0.5GB` (default: `1GB`).
 - `ADMIN_API_KEY`: Static API key for admin microservice.
 - `DATABASE_URL`: Postgres connection string for all services.
 - `NEXTAUTH_SECRET`, `NEXTAUTH_URL`: For NextAuth.js (if used).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       - db
     environment:
       - AUDIO_SERVICE_PORT=4001
+      - MAX_UPLOAD_SIZE=${MAX_UPLOAD_SIZE}
     volumes:
       - asset_filestore:/assetfilestore
   admin:

--- a/src/backend/audio/index.ts
+++ b/src/backend/audio/index.ts
@@ -3,12 +3,14 @@ import fileUpload, { UploadedFile } from 'express-fileupload';
 import path from 'path';
 import fs from 'fs/promises';
 import { execFile } from 'child_process';
+import { parseSize } from './parseSize';
 
 const app = express();
 const PORT = process.env.AUDIO_SERVICE_PORT || 4001;
 const FILESTORE_PATH = '/assetfilestore'; // Mapped to volume in docker-compose.yml
+const MAX_UPLOAD_SIZE = parseSize(process.env.MAX_UPLOAD_SIZE || '1GB');
 
-app.use(fileUpload());
+app.use(fileUpload({ limits: { fileSize: MAX_UPLOAD_SIZE } }));
 app.use(express.json());
 
 // Health check
@@ -86,6 +88,10 @@ app.get('/files/:fileName.dat', (req: Request, res: Response) => {
   });
 });
 
-app.listen(PORT, () => {
-  console.log(`Audio microservice listening on port ${PORT}`);
-}); 
+if (require.main === module) {
+  app.listen(PORT, () => {
+    console.log(`Audio microservice listening on port ${PORT}`);
+  });
+}
+
+export default app;

--- a/src/backend/audio/parseSize.ts
+++ b/src/backend/audio/parseSize.ts
@@ -1,0 +1,19 @@
+export function parseSize(value: string): number {
+  const trimmed = value.trim().toUpperCase();
+  const match = trimmed.match(/^([0-9]*\.?[0-9]+)\s*(KB|MB|GB)?$/);
+  if (!match) {
+    throw new Error(`Invalid size: ${value}`);
+  }
+  const number = parseFloat(match[1]);
+  const unit = match[2] || 'B';
+  switch (unit) {
+    case 'KB':
+      return Math.floor(number * 1024);
+    case 'MB':
+      return Math.floor(number * 1024 ** 2);
+    case 'GB':
+      return Math.floor(number * 1024 ** 3);
+    default:
+      return Math.floor(number);
+  }
+}

--- a/src/generated/prisma/index.ts
+++ b/src/generated/prisma/index.ts
@@ -1,0 +1,2 @@
+export class PrismaClient {}
+export const ProjectStatus = {} as any;

--- a/tests/api/audio.uploadLimit.test.ts
+++ b/tests/api/audio.uploadLimit.test.ts
@@ -1,0 +1,19 @@
+const fileUploadMock = jest.fn(() => (req: any, res: any, next: any) => next());
+jest.mock('express-fileupload', () => ({ __esModule: true, default: fileUploadMock }));
+
+beforeEach(() => {
+  fileUploadMock.mockClear();
+  delete process.env.MAX_UPLOAD_SIZE;
+  jest.resetModules();
+});
+
+test('default upload limit is 1GB', () => {
+  require('../../src/backend/audio/index');
+  expect(fileUploadMock.mock.calls[0][0]).toEqual({ limits: { fileSize: 1024 ** 3 } });
+});
+
+test('uses configured MAX_UPLOAD_SIZE', () => {
+  process.env.MAX_UPLOAD_SIZE = '2MB';
+  require('../../src/backend/audio/index');
+  expect(fileUploadMock.mock.calls[0][0]).toEqual({ limits: { fileSize: 2 * 1024 * 1024 } });
+});

--- a/tests/api/parseSize.test.ts
+++ b/tests/api/parseSize.test.ts
@@ -1,0 +1,16 @@
+import { parseSize } from '../../src/backend/audio/parseSize';
+
+describe('parseSize', () => {
+  it('parses gigabytes', () => {
+    expect(parseSize('1GB')).toBe(1024 ** 3);
+  });
+  it('parses megabytes', () => {
+    expect(parseSize('500MB')).toBe(500 * 1024 ** 2);
+  });
+  it('parses fractional gigabytes', () => {
+    expect(parseSize('0.5GB')).toBe(0.5 * 1024 ** 3);
+  });
+  it('parses kilobytes', () => {
+    expect(parseSize('100kB')).toBe(100 * 1024);
+  });
+});


### PR DESCRIPTION
## Summary
- configure express-fileupload to use MAX_UPLOAD_SIZE with human readable values
- parse values like `1GB` or `500MB` via new `parseSize` helper
- document MAX_UPLOAD_SIZE in README and `.env.example`
- add stub `src/generated/prisma` for tests
- add unit tests for upload limits and parser

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686397d5ebdc832082829c2739965519