### PR TITLE
Fix tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -15,6 +15,7 @@ module.exports = {
   moduleNameMapper: {
     '^@/generated/prisma$': '<rootDir>/src/generated/prisma',
     '^@/generated/prisma/(.*)$': '<rootDir>/src/generated/prisma/$1',
+    '^@/(.*)$': '<rootDir>/src/$1',
     '\\.(css|less|scss|sass)$': 'identity-obj-proxy',
     '\\.(jpg|jpeg|png|gif|webp|svg)$': '<rootDir>/__mocks__/fileMock.js',
     '^next/(.*)$': '<rootDir>/node_modules/next/$1',

--- a/src/app/api/auth/session.ts
+++ b/src/app/api/auth/session.ts
@@ -21,7 +21,7 @@ export async function createSession(userId: number) {
 export async function validateSession(req?: NextRequest): Promise<{ userId: number; type: string } | null> {
   let token: string | undefined;
   if (req) {
-    const auth = req.headers.get('authorization');
+    const auth = req.headers?.get('authorization');
     if (auth?.startsWith('Bearer ')) token = auth.slice(7);
   }
   if (!token) {


### PR DESCRIPTION
## Summary
- support `@/` alias in Jest
- avoid error when request headers are missing in session validation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686660387cc8832089def314a0c9154a