### PR TITLE
Add Playwright E2E testing setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,7 @@ All audio and waveform file requests from the frontend are proxied through the N
 - **Waveform Pre-Compute:** On upload, the audio microservice runs `audiowaveform` to generate a `.dat` file for fast waveform rendering in the UI.
 - **File Storage:** All audio and waveform files are stored in a Docker volume at `/assetfilestore` inside the audio microservice. They are not accessible from the Next.js app or the host filesystem.
 - **Tests:** Run `npm test` to execute all API and UI tests.
+- **E2E Tests:** Run `npm run test:e2e` to execute the Playwright end-to-end suite.
 
 ---
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -11,7 +11,7 @@ module.exports = {
   transform: {
     '^.+\\.(ts|tsx)$': 'ts-jest',
   },
-  testPathIgnorePatterns: ['/node_modules/', '/.next/', '/filestore/'],
+  testPathIgnorePatterns: ['/node_modules/', '/.next/', '/filestore/', '/tests/e2e/'],
   moduleNameMapper: {
     '^@/generated/prisma$': '<rootDir>/src/generated/prisma',
     '^@/generated/prisma/(.*)$': '<rootDir>/src/generated/prisma/$1',

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
+        "@playwright/test": "^1.53.2",
         "@tailwindcss/postcss": "^4",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
@@ -1877,6 +1878,22 @@
       "dev": true,
       "dependencies": {
         "@noble/hashes": "^1.1.5"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.53.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.53.2.tgz",
+      "integrity": "sha512-tEB2U5z74ebBeyfGNZ3Jfg29AnW+5HlWhvHtb/Mqco9pFdZU1ZLNdVb2UtB5CvmiilNr2ZfVH/qMmAROG/XTzw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.53.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@prisma/client": {
@@ -8696,6 +8713,53 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.53.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.53.2.tgz",
+      "integrity": "sha512-6K/qQxVFuVQhRQhFsVZ9fGeatxirtrpPgxzBYWyZLEXJzqYwuL4fuNmfOfD5et1tJE4GScKyPNeLhZeRwuTU3A==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.53.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.53.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.53.2.tgz",
+      "integrity": "sha512-ox/OytMy+2w1jcYEYlOo1Hhp8hZkLCximMTUTMBXjGUA1KoFfiSZ+DU+3a739jsPY0yoKH2TFy9S2fsJas8yAw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test:api": "jest --testPathPattern=tests/api",
     "test:ui": "jest --testPathPattern=tests/ui",
     "test:coverage": "jest --coverage",
+    "test:e2e": "playwright test",
     "reset": "npx prisma migrate reset --force && rm -rf public/filestore/*",
     "start:audio-service": "npm start --prefix src/backend/audio",
     "build:audio-service": "npm run build --prefix src/backend/audio"
@@ -55,6 +56,7 @@
     "supertest": "^7.1.1",
     "tailwindcss": "^4",
     "ts-jest": "^29.3.4",
+    "@playwright/test": "^1.53.2",
     "typescript": "^5"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,9 @@
+import { PlaywrightTestConfig } from '@playwright/test';
+
+const config: PlaywrightTestConfig = {
+  testDir: './tests/e2e',
+  globalSetup: require.resolve('./playwright.global-setup'),
+  globalTeardown: require.resolve('./playwright.global-teardown'),
+};
+
+export default config;

--- a/playwright.global-setup.ts
+++ b/playwright.global-setup.ts
@@ -1,0 +1,4 @@
+import { execSync } from 'child_process';
+export default async function globalSetup() {
+  execSync('docker compose up -d', { stdio: 'inherit' });
+}

--- a/playwright.global-teardown.ts
+++ b/playwright.global-teardown.ts
@@ -1,0 +1,4 @@
+import { execSync } from 'child_process';
+export default async function globalTeardown() {
+  execSync('docker compose down', { stdio: 'inherit' });
+}

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from '@playwright/test';
+
+const OK_OR_REDIRECT = [200, 301, 302, 303, 307, 308];
+
+test('web app responds', async ({ request }) => {
+  const response = await request.get('http://localhost:3000');
+  expect(OK_OR_REDIRECT).toContain(response.status());
+});
+
+test('audio service health', async ({ request }) => {
+  const response = await request.get('http://localhost:4001/health');
+  expect(response.status()).toBe(200);
+});
+
+test('admin service health', async ({ request }) => {
+  const response = await request.get('http://localhost:4002/health');
+  expect(response.status()).toBe(200);
+});
+


### PR DESCRIPTION
## Summary
- add Playwright dependency and new `test:e2e` npm script
- configure Playwright with docker compose setup/teardown
- create simple smoke test
- ignore e2e folder from Jest
- document how to run the E2E tests

## Testing
- `npm test`
- `npm run test:e2e` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866628166fc8320b9e8796b7c2f2e60