### PR TITLE
Add local services start script

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -22,7 +22,7 @@ module.exports = {
   },
   collectCoverage: true,
   coverageDirectory: 'coverage',
-  setupFiles: ['<rootDir>/jest.setup.js'],
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
   globals: {
     'ts-jest': {
       tsconfig: 'tsconfig.jest.json',

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -35,4 +35,18 @@ if (!global.fetch) {
       json: () => Promise.resolve({}),
     })
   );
-} 
+}
+
+// React Testing Library expects React.act to be defined. Attach the
+// implementation from react-dom/test-utils when running tests.
+const React = require('react');
+if (!React.act) {
+  const ReactDOM = require('react-dom');
+  React.act = callback => {
+    let result;
+    ReactDOM.flushSync(() => {
+      result = callback();
+    });
+    return result;
+  };
+}

--- a/local-start.sh
+++ b/local-start.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -e
+
+# Build prisma client
+npm run generate:schema
+
+# Build audio microservice
+npm --prefix src/backend/audio run build
+
+# Build admin microservice (copy prisma client and compile)
+npm --prefix src/backend/admin run build:prep
+npm --prefix src/backend/admin run build
+
+# Build Next.js app
+npm run build
+
+# Default environment variables
+export DATABASE_URL="${DATABASE_URL:-postgresql://postgres:${POSTGRES_PASSWORD}@localhost:5432/bandbridge}"
+export AUDIO_SERVICE_URL="${AUDIO_SERVICE_URL:-http://localhost:4001}"
+export ADMIN_API_KEY="${ADMIN_API_KEY:-changeme}"
+export MAX_UPLOAD_SIZE="${MAX_UPLOAD_SIZE:-1GB}"
+
+# Start services
+npm --prefix src/backend/audio start &
+audio_pid=$!
+
+npm --prefix src/backend/admin start &
+admin_pid=$!
+
+npm start &
+web_pid=$!
+
+trap 'echo Stopping...; kill $audio_pid $admin_pid $web_pid' INT TERM
+
+wait $web_pid


### PR DESCRIPTION
## Summary
- add `local-start.sh` to build and launch web, audio and admin services with a local Postgres instance
- configure Jest to load setup after environment
- polyfill `React.act` for React Testing Library

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686699d686408320934168937908f6fa