### PR TITLE
Fix admin build and enable e2e test

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,8 +12,13 @@ const compat = new FlatCompat({
 const eslintConfig = [
   ...compat.extends("next/core-web-vitals", "next/typescript"),
   {
-    ignores: ["./src/generated/**/*", "./src/backend/admin/generated", 
-      "./src/backend/audio/dist", "./dist"],
+    ignores: [
+      "./src/generated/**/*",
+      "./src/backend/admin/generated",
+      "./src/backend/admin/dist",
+      "./src/backend/audio/dist",
+      "./dist"
+    ],
   },
 ];
 

--- a/src/backend/admin/package.json
+++ b/src/backend/admin/package.json
@@ -5,9 +5,9 @@
   "type": "module",
   "scripts": {
     "dev": "nodemon src/index.ts",
-    "start": "node dist/index.js",
-    "build": "echo 'Run build:prep if build fails on prisma files' && tsc",
-    "build:prep": "rm -rf generated && mkdir -p generated && cp -R ../../../src/generated/prisma generated",
+    "start": "node dist/src/index.js",
+    "build": "echo 'Run build:prep if build fails on prisma files' && tsc && cp -R generated dist/generated",
+    "build:prep": "rm -rf generated && mkdir -p generated && cp -R ../../../src/generated/prisma generated && rm -f generated/prisma/index.ts",
     "clean": "rm -rf dist generated"
   },
   "dependencies": {

--- a/src/backend/admin/src/prisma.ts
+++ b/src/backend/admin/src/prisma.ts
@@ -1,4 +1,6 @@
-import { PrismaClient } from '../generated/prisma/index.js';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const { PrismaClient } = require('../generated/prisma');
 
 const prisma = new PrismaClient();
 export default prisma; 

--- a/src/backend/admin/tsconfig.json
+++ b/src/backend/admin/tsconfig.json
@@ -8,8 +8,9 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "allowJs": true
   },
-  "include": ["src/**/*.ts", "generated/**/*.ts"],
+  "include": ["src/**/*.ts", "generated/**/*.d.ts", "generated/**/*.js"],
   "exclude": ["node_modules", "dist"]
 } 


### PR DESCRIPTION
## Summary
- ignore admin build output in ESLint
- fix build scripts for admin service
- adjust Prisma client import for ES modules
- allow JS files in admin TypeScript config

## Testing
- `NO_DOCKER=1 npx playwright test tests/e2e/smoke.spec.ts`

------
https://chatgpt.com/codex/tasks/task_e_6866a131fdf48320953c4bf3f0f9f3f5