### PR TITLE
Fix build process requiring postcss plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,12 +27,12 @@
         "prisma": "^6.8.2",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "wavesurfer.js": "^7.9.5"
+        "wavesurfer.js": "^7.9.5",
+        "@tailwindcss/postcss": "^4"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
         "@playwright/test": "^1.53.2",
-        "@tailwindcss/postcss": "^4",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",

--- a/package.json
+++ b/package.json
@@ -37,11 +37,11 @@
     "prisma": "^6.8.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "wavesurfer.js": "^7.9.5"
+    "wavesurfer.js": "^7.9.5",
+    "@tailwindcss/postcss": "^4"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
-    "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",


### PR DESCRIPTION
## Summary
- install `@tailwindcss/postcss` as a regular dependency so `next build` works even when dev dependencies aren't installed

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6866e77ff6f483209ac3c516ba4aa184