### PR TITLE
Add video media support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Band Bridge
 
-A web app for band collaboration: create projects, upload songs, and comment on songs with time-based markers. Built with Next.js, React, TypeScript, Tailwind CSS, and Postgres (via Prisma). Audio files and waveform data are managed by a dedicated microservice. User, band, and API key management is handled by a secure admin microservice.
+A web app for band collaboration: create projects, upload media, and comment on media with time-based markers. Built with Next.js, React, TypeScript, Tailwind CSS, and Postgres (via Prisma). Audio and video files are managed by a dedicated microservice. User, band, and API key management is handled by a secure admin microservice.
 
 <picture>
    <img src="doc/project-dashboard.png" alt="Screenshot project dashboard" width="320" />
@@ -11,7 +11,7 @@ A web app for band collaboration: create projects, upload songs, and comment on 
 </picture>
 
 <picture>
-   <img src="doc/song-view.png" alt="Screenshot song view" width="320" />
+   <img src="doc/media-view.png" alt="Screenshot song view" width="320" />
 </picture>
 
 ---
@@ -19,10 +19,10 @@ A web app for band collaboration: create projects, upload songs, and comment on 
 ## Features
 
 - Band/project management
-- Song upload (MP3/WAV), download, and deletion
+- Media upload (audio MP3/WAV and video MP4/MOV/AVI/H.264), download, and deletion
 - Precomputed waveform rendering for instant audio visualization
-- Time-based comments on songs
-- Deep links to song details (with share button)
+- Time-based comments on media items
+- Deep links to media details (with share button)
 - Responsive, modern UI (Next.js, Tailwind CSS)
 - Robust API and UI test suite
 - Admin microservice for user, band, and API key management There is no admin UI. Use curl (see examples below)
@@ -107,7 +107,7 @@ band-bridge/
   - Located at `src/backend/audio/`
   - Handles audio file uploads, deletions, and waveform pre-computation using [BBC audiowaveform](https://github.com/bbc/audiowaveform).
   - All audio and waveform files are stored in a Docker volume mounted at `/assetfilestore` inside the audio microservice container. This volume is not directly accessible from the host or the Next.js app.
-  - Waveform data is saved as `.dat` files next to the audio files (e.g., `song.wav` → `song.wav.dat`).
+  - Waveform data is saved as `.dat` files next to the audio files (e.g., `media.wav` → `media.wav.dat`).
 
 - **Admin Microservice:**
   - Located at `src/backend/admin/`
@@ -118,8 +118,8 @@ band-bridge/
 
 ## UI/UX
 
-- Download, delete, and share buttons are consistently placed at the top right of each song card and the song details page.
-- Sharing a song copies a deep link to the clipboard and shows a toast notification.
+- Download, delete, and share buttons are consistently placed at the top right of each media card and the media details page.
+- Sharing a media copies a deep link to the clipboard and shows a toast notification.
 - All file and waveform requests are proxied through the Next.js API for security and abstraction.
 
 
@@ -127,7 +127,7 @@ band-bridge/
 
 ## Deep Linking & Sharing
 
-Every song has a unique URL (`/project/[projectId]/song/[songId]`). Use the share button to copy a direct link to the clipboard.
+Every media item has a unique URL (`/project/[projectId]/media/[mediaId]`). Use the share button to copy a direct link to the clipboard.
 
 ---
 
@@ -138,18 +138,18 @@ Every song has a unique URL (`/project/[projectId]/song/[songId]`). Use the shar
 curl http://localhost:4001/health
 ```
 
-### Upload Audio File (with waveform pre-compute)
+### Upload Media File
 ```sh
-curl -F "file=@/path/to/song.wav" http://localhost:4001/upload
+curl -F "file=@/path/to/file.mp4" http://localhost:4001/upload
 ```
-- Response: `{ "fileName": "<timestamp>_song.wav" }`
-- Also creates `<timestamp>_song.wav.dat` in the filestore.
+- Response: `{ "fileName": "<timestamp>_file.wav" }`
+- Also creates `<timestamp>_file.wav.dat` in the filestore.
 
-### Delete Audio File and Waveform Data
+### Delete Media File
 ```sh
-curl -X DELETE http://localhost:4001/delete-song \
+curl -X DELETE http://localhost:4001/delete-media \
   -H "Content-Type: application/json" \
-  -d '{"fileName":"<timestamp>_song.wav"}'
+  -d '{"fileName":"<timestamp>_file.mp4"}'
 ```
 - Deletes both the audio file and its `.dat` waveform file.
 
@@ -238,47 +238,47 @@ curl -X POST http://localhost:4002/admin/apikeys/1/revoke \
   curl -X DELETE http://localhost:3000/api/project/1
   ```
 
-### Songs
+### Media
 
-- **List Songs in Project**
+- **List Media in Project**
   ```sh
-  curl http://localhost:3000/api/project/1/song
+  curl http://localhost:3000/api/project/1/media
   ```
-- **Get Song**
+- **Get Media**
   ```sh
-  curl http://localhost:3000/api/project/1/song/2
+  curl http://localhost:3000/api/project/1/media/2
   ```
-- **Upload Song**
+- **Upload Media (audio/video)**
   ```sh
-  curl -F "file=@/path/to/song.wav" -F "title=My Song" http://localhost:3000/api/project/1/song
+  curl -F "file=@/path/to/file.mp4" -F "title=My File" http://localhost:3000/api/project/1/media
   ```
-- **Delete Song**
+- **Delete Media**
   ```sh
-  curl -X DELETE http://localhost:3000/api/project/1/song/2
+  curl -X DELETE http://localhost:3000/api/project/1/media/2
   ```
 
 ### Comments
 
-- **List Comments for Song**
+- **List Comments for Media**
   ```sh
-  curl http://localhost:3000/api/project/1/song/2/comment
+  curl http://localhost:3000/api/project/1/media/2/comment
   ```
 - **Add Comment (requires authentication)**
   ```sh
-  curl -X POST http://localhost:3000/api/project/1/song/2/comment \
+  curl -X POST http://localhost:3000/api/project/1/media/2/comment \
     -H "Content-Type: application/json" \
-    -d '{"text":"Great solo!","time":42.5}'
+    -d '{"text":"Great comment!","time":42.5}'
   ```
 
 ### Audio Proxy Endpoints
 
 - **Download Audio File**
   ```sh
-  curl http://localhost:3000/api/project/1/song/audio?file=<fileName>
+  curl http://localhost:3000/api/project/1/media/audio?file=<fileName>
   ```
 - **Download Waveform Data**
   ```sh
-  curl http://localhost:3000/api/project/1/song/waveform?file=<fileName>
+  curl http://localhost:3000/api/project/1/media/waveform?file=<fileName>
   ```
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@prisma/client": "^6.8.2",
+        "@tailwindcss/postcss": "^4",
         "@types/bcrypt": "^5.0.2",
         "@types/dotenv": "^8.2.3",
         "@types/express": "^5.0.2",
@@ -27,8 +28,7 @@
         "prisma": "^6.8.2",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "wavesurfer.js": "^7.9.5",
-        "@tailwindcss/postcss": "^4"
+        "wavesurfer.js": "^7.9.5"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -47,7 +47,9 @@
         "supertest": "^7.1.1",
         "tailwindcss": "^4",
         "ts-jest": "^29.3.4",
-        "typescript": "^5"
+        "typescript": "^5",
+        "video.js": "^7.21.7",
+        "videojs-markers": "^1.0.1"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -60,7 +62,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
       "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -72,7 +73,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
       "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
@@ -585,7 +585,6 @@
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.4.3.tgz",
       "integrity": "sha512-4m62DuCE07lw01soJwPiBGC0nAww0Q+RY70VZ+n49yDIO13yyinhbWCeNnaob0lakDtWQzSdtNWzJeOJt2ma+g==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.0.2",
@@ -605,7 +604,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.0.2.tgz",
       "integrity": "sha512-5n3nTJblwRi8LlXkJ9eBzu+kZR8Yxcc7ubakyQTFzPMtIhFpUBRbsnc2Dv88IZDIbCDlBiWrknhB4Lsz7mg6BA==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
@@ -1182,7 +1180,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
       "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
-      "dev": true,
       "dependencies": {
         "minipass": "^7.0.4"
       },
@@ -1625,7 +1622,6 @@
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
       "integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/set-array": "^1.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -1639,7 +1635,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -1648,7 +1643,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
       "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
-      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -1656,14 +1650,12 @@
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
-      "dev": true
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.25",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
       "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -1673,7 +1665,6 @@
       "version": "0.2.10",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.10.tgz",
       "integrity": "sha512-bCsCyeZEwVErsGmyPNSzwfwFn4OdxBj0mmv6hOFucB/k81Ojdu68RbZdxYsRQUPc9l6SU5F/cG+bXgWs3oUgsQ==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "@emnapi/core": "^1.4.3",
@@ -2018,7 +2009,6 @@
       "version": "4.1.7",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.1.7.tgz",
       "integrity": "sha512-9rsOpdY9idRI2NH6CL4wORFY0+Q6fnx9XP9Ju+iq/0wJwGD5IByIgFmwVbyy4ymuyprj8Qh4ErxMKTUL4uNh3g==",
-      "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.3.0",
         "enhanced-resolve": "^5.18.1",
@@ -2033,7 +2023,6 @@
       "version": "4.1.7",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.1.7.tgz",
       "integrity": "sha512-5SF95Ctm9DFiUyjUPnDGkoKItPX/k+xifcQhcqX5RA85m50jw1pT/KzjdvlqxRja45Y52nR4MR9fD1JYd7f8NQ==",
-      "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "detect-libc": "^2.0.4",
@@ -2064,7 +2053,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -2080,7 +2068,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -2096,7 +2083,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -2112,7 +2098,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -2128,7 +2113,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2144,7 +2128,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2160,7 +2143,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2176,7 +2158,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2192,7 +2173,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -2216,7 +2196,6 @@
       "cpu": [
         "wasm32"
       ],
-      "dev": true,
       "optional": true,
       "dependencies": {
         "@emnapi/core": "^1.4.3",
@@ -2237,7 +2216,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -2253,7 +2231,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -2266,7 +2243,6 @@
       "version": "4.1.7",
       "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.1.7.tgz",
       "integrity": "sha512-88g3qmNZn7jDgrrcp3ZXEQfp9CVox7xjP1HN2TFKI03CltPVd/c61ydn5qJJL8FYunn0OqBaW5HNUga0kmPVvw==",
-      "dev": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "@tailwindcss/node": "4.1.7",
@@ -2432,7 +2408,6 @@
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.9.0.tgz",
       "integrity": "sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
@@ -3207,6 +3182,68 @@
         "win32"
       ]
     },
+    "node_modules/@videojs/http-streaming": {
+      "version": "2.16.3",
+      "resolved": "https://registry.npmjs.org/@videojs/http-streaming/-/http-streaming-2.16.3.tgz",
+      "integrity": "sha512-91CJv5PnFBzNBvyEjt+9cPzTK/xoVixARj2g7ZAvItA+5bx8VKdk5RxCz/PP2kdzz9W+NiDUMPkdmTsosmy69Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@videojs/vhs-utils": "3.0.5",
+        "aes-decrypter": "3.1.3",
+        "global": "^4.4.0",
+        "m3u8-parser": "4.8.0",
+        "mpd-parser": "^0.22.1",
+        "mux.js": "6.0.1",
+        "video.js": "^6 || ^7"
+      },
+      "engines": {
+        "node": ">=8",
+        "npm": ">=5"
+      },
+      "peerDependencies": {
+        "video.js": "^6 || ^7"
+      }
+    },
+    "node_modules/@videojs/vhs-utils": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@videojs/vhs-utils/-/vhs-utils-3.0.5.tgz",
+      "integrity": "sha512-PKVgdo8/GReqdx512F+ombhS+Bzogiofy1LgAj4tN8PfdBx3HSS7V5WfJotKTqtOWGwVfSWsrYN/t09/DSryrw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "global": "^4.4.0",
+        "url-toolkit": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8",
+        "npm": ">=5"
+      }
+    },
+    "node_modules/@videojs/xhr": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@videojs/xhr/-/xhr-2.6.0.tgz",
+      "integrity": "sha512-7J361GiN1tXpm+gd0xz2QWr3xNWBE+rytvo8J3KuggFaLg+U37gZQ2BuPLcnkfGffy2e+ozY70RHC8jt7zjA6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "global": "~4.4.0",
+        "is-function": "^1.0.1"
+      }
+    },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.8.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
+      "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/abab": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
@@ -3286,6 +3323,19 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/aes-decrypter": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/aes-decrypter/-/aes-decrypter-3.1.3.tgz",
+      "integrity": "sha512-VkG9g4BbhMBy+N5/XodDeV6F02chEk9IpgRTq/0bS80y4dzy79VH2Gtms02VXomf3HmyRe3yyJYkJ990ns+d6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@videojs/vhs-utils": "^3.0.5",
+        "global": "^4.4.0",
+        "pkcs7": "^1.0.4"
       }
     },
     "node_modules/agent-base": {
@@ -3966,7 +4016,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
       "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
-      "dev": true,
       "engines": {
         "node": ">=18"
       }
@@ -4443,7 +4492,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
       "integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==",
-      "devOptional": true,
       "engines": {
         "node": ">=8"
       }
@@ -4494,6 +4542,12 @@
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
       "peer": true
+    },
+    "node_modules/dom-walk": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
+      "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w==",
+      "dev": true
     },
     "node_modules/domexception": {
       "version": "4.0.0",
@@ -4588,7 +4642,6 @@
       "version": "5.18.1",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.1.tgz",
       "integrity": "sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg==",
-      "dev": true,
       "dependencies": {
         "graceful-fs": "^4.2.4",
         "tapable": "^2.2.0"
@@ -5807,6 +5860,17 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/global": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
+      "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-document": "^2.19.0",
+        "process": "^0.11.10"
+      }
+    },
     "node_modules/globals": {
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
@@ -5849,8 +5913,7 @@
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
     "node_modules/graphemer": {
       "version": "1.4.0",
@@ -6084,6 +6147,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/individual": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/individual/-/individual-2.0.0.tgz",
+      "integrity": "sha512-pWt8hBCqJsUWI/HtcfWod7+N9SgAqyPEaF7JQjwzjn5vGrpg6aQ5qeAFQ7dx//UH4J1O+7xqew+gCeeFt6xN/g==",
+      "dev": true
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -6296,6 +6365,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/is-function": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.2.tgz",
+      "integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-generator-fn": {
       "version": "2.1.0",
@@ -7370,6 +7446,13 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/keycode": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/keycode/-/keycode-2.2.1.tgz",
+      "integrity": "sha512-Rdgz9Hl9Iv4QKi8b0OlCRQEzp4AgVxyCtz5S/+VIHezDmrDhkp2N2TqBWOLz0/gbeREXOOiI9/4b8BY9uw2vFg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -7432,7 +7515,6 @@
       "version": "1.30.1",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.30.1.tgz",
       "integrity": "sha512-xi6IyHML+c9+Q3W0S4fCQJOym42pyurFiJUHEcEyHS0CeKzia4yZDEsLlqOFykxOdHpNy0NmvVO31vcSqAxJCg==",
-      "dev": true,
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -7463,7 +7545,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -7483,7 +7564,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -7503,7 +7583,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -7523,7 +7602,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -7543,7 +7621,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -7563,7 +7640,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -7583,7 +7659,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -7603,7 +7678,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -7623,7 +7697,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -7643,7 +7716,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -7732,11 +7804,22 @@
         "lz-string": "bin/bin.js"
       }
     },
+    "node_modules/m3u8-parser": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/m3u8-parser/-/m3u8-parser-4.8.0.tgz",
+      "integrity": "sha512-UqA2a/Pw3liR6Df3gwxrqghCP17OpPlQj6RBPLYygf/ZSQ4MoSgvdvhvt35qV+3NaaA0FSZx93Ix+2brT1U7cA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@videojs/vhs-utils": "^3.0.5",
+        "global": "^4.4.0"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.17",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
       "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0"
       }
@@ -7875,6 +7958,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/min-document": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
+      "integrity": "sha512-9Wy1B3m3f66bPPmU5hdA4DR4PB2OfDU/+GS3yAB7IQozE3tqXaVv2zOjgla7MEGSRv95+ILmOuvhLkOK6wJtCQ==",
+      "dev": true,
+      "dependencies": {
+        "dom-walk": "^0.1.0"
+      }
+    },
     "node_modules/min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -7909,7 +8001,6 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-      "dev": true,
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -7918,7 +8009,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.0.2.tgz",
       "integrity": "sha512-oG62iEk+CYt5Xj2YqI5Xi9xWUeZhDI8jjQmC5oThVH5JGCTgIjr7ciJDzC7MBzYd//WvR1OTmP5Q38Q8ShQtVA==",
-      "dev": true,
       "dependencies": {
         "minipass": "^7.1.2"
       },
@@ -7930,7 +8020,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
       "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
-      "dev": true,
       "bin": {
         "mkdirp": "dist/cjs/src/bin.js"
       },
@@ -7941,10 +8030,44 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/mpd-parser": {
+      "version": "0.22.1",
+      "resolved": "https://registry.npmjs.org/mpd-parser/-/mpd-parser-0.22.1.tgz",
+      "integrity": "sha512-fwBebvpyPUU8bOzvhX0VQZgSohncbgYwUyJJoTSNpmy7ccD2ryiCvM7oRkn/xQH5cv73/xU7rJSNCLjdGFor0Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@videojs/vhs-utils": "^3.0.5",
+        "@xmldom/xmldom": "^0.8.3",
+        "global": "^4.4.0"
+      },
+      "bin": {
+        "mpd-to-m3u8-json": "bin/parse.js"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/mux.js": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/mux.js/-/mux.js-6.0.1.tgz",
+      "integrity": "sha512-22CHb59rH8pWGcPGW5Og7JngJ9s+z4XuSlYvnxhLuc58cA1WqGDQPzuG8I+sPm1/p0CdgpzVTaKW408k5DNn8w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.11.2",
+        "global": "^4.4.0"
+      },
+      "bin": {
+        "muxjs-transmux": "bin/transmux.js"
+      },
+      "engines": {
+        "node": ">=8",
+        "npm": ">=5"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -8651,6 +8774,19 @@
         "node": ">= 6"
       }
     },
+    "node_modules/pkcs7": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/pkcs7/-/pkcs7-1.0.4.tgz",
+      "integrity": "sha512-afRERtHn54AlwaF2/+LFszyAANTCggGilmcmILUzEjvs3XgFZT+xE6+QWQcAGmu4xajy+Xtj7acLOPdx5/eXWQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5"
+      },
+      "bin": {
+        "pkcs7": "bin/cli.js"
+      }
+    },
     "node_modules/pkg-dir": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
@@ -8775,7 +8911,6 @@
       "version": "8.5.3",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
       "integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -8902,6 +9037,16 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/prompts": {
@@ -9250,6 +9395,16 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/rust-result": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/rust-result/-/rust-result-1.0.0.tgz",
+      "integrity": "sha512-6cJzSBU+J/RJCF063onnQf0cDUOHs9uZI1oroSGnHOph+CQTIJ5Pp2hK5kEQq1+7yE/EEWfulSNXAQ2jikPthA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "individual": "^2.0.0"
+      }
+    },
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
@@ -9287,6 +9442,15 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/safe-json-parse": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/safe-json-parse/-/safe-json-parse-4.0.0.tgz",
+      "integrity": "sha512-RjZPPHugjK0TOzFrLZ8inw44s9bKox99/0AZW9o/BEQVrJfhI+fIHMErnPyRa89/yRXUUr93q+tiN6zhoVV4wQ==",
+      "dev": true,
+      "dependencies": {
+        "rust-result": "^1.0.0"
+      }
     },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
@@ -9986,14 +10150,12 @@
     "node_modules/tailwindcss": {
       "version": "4.1.7",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.7.tgz",
-      "integrity": "sha512-kr1o/ErIdNhTz8uzAYL7TpaUuzKIE6QPQ4qmSdxnoX/lo+5wmUHQA6h3L5yIqEImSRnAAURDirLu/BgiXGPAhg==",
-      "dev": true
+      "integrity": "sha512-kr1o/ErIdNhTz8uzAYL7TpaUuzKIE6QPQ4qmSdxnoX/lo+5wmUHQA6h3L5yIqEImSRnAAURDirLu/BgiXGPAhg=="
     },
     "node_modules/tapable": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.2.tgz",
       "integrity": "sha512-Re10+NauLTMCudc7T5WLFLAwDhQ0JWdrMK+9B2M8zR5hRExKmsRDCBA7/aV/pNJFltmBFO5BAMlQFi/vq3nKOg==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -10002,7 +10164,6 @@
       "version": "7.4.3",
       "resolved": "https://registry.npmjs.org/tar/-/tar-7.4.3.tgz",
       "integrity": "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==",
-      "dev": true,
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
         "chownr": "^3.0.0",
@@ -10499,6 +10660,13 @@
         "requires-port": "^1.0.0"
       }
     },
+    "node_modules/url-toolkit": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/url-toolkit/-/url-toolkit-2.2.5.tgz",
+      "integrity": "sha512-mtN6xk+Nac+oyJ/PrI7tzfmomRVNFIWKUbG8jdYFt52hxbiReFAXIjYskvu64/dvuW71IcB7lV8l0HvZMac6Jg==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
@@ -10519,6 +10687,54 @@
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/video.js": {
+      "version": "7.21.7",
+      "resolved": "https://registry.npmjs.org/video.js/-/video.js-7.21.7.tgz",
+      "integrity": "sha512-T2s3WFAht7Zjr2OSJamND9x9Dn2O+Z5WuHGdh8jI5SYh5mkMdVTQ7vSRmA5PYpjXJ2ycch6jpMjkJEIEU2xxqw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@videojs/http-streaming": "2.16.3",
+        "@videojs/vhs-utils": "^3.0.4",
+        "@videojs/xhr": "2.6.0",
+        "aes-decrypter": "3.1.3",
+        "global": "^4.4.0",
+        "keycode": "^2.2.0",
+        "m3u8-parser": "4.8.0",
+        "mpd-parser": "0.22.1",
+        "mux.js": "6.0.1",
+        "safe-json-parse": "4.0.0",
+        "videojs-font": "3.2.0",
+        "videojs-vtt.js": "^0.15.5"
+      }
+    },
+    "node_modules/videojs-font": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/videojs-font/-/videojs-font-3.2.0.tgz",
+      "integrity": "sha512-g8vHMKK2/JGorSfqAZQUmYYNnXmfec4MLhwtEFS+mMs2IDY398GLysy6BH6K+aS1KMNu/xWZ8Sue/X/mdQPliA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/videojs-markers": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/videojs-markers/-/videojs-markers-1.0.1.tgz",
+      "integrity": "sha512-jw3jRhanwno0YgdRR9+z6cbdmMs/jeXcrgkMr6mlEP+XfZN+isWNYp0GnPvdXrBcnb6AANdDHlnXSmIvecEzWA==",
+      "dev": true,
+      "peerDependencies": {
+        "video.js": ">=4"
+      }
+    },
+    "node_modules/videojs-vtt.js": {
+      "version": "0.15.5",
+      "resolved": "https://registry.npmjs.org/videojs-vtt.js/-/videojs-vtt.js-0.15.5.tgz",
+      "integrity": "sha512-yZbBxvA7QMYn15Lr/ZfhhLPrNpI/RmCSCqgIff57GC2gIrV5YfyzLfLyZMj0NnZSAz8syB4N0nHXpZg9MyrMOQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "global": "^4.3.1"
       }
     },
     "node_modules/w3c-xmlserializer": {
@@ -10791,7 +11007,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
       "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-      "dev": true,
       "engines": {
         "node": ">=18"
       }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@prisma/client": "^6.8.2",
+    "@tailwindcss/postcss": "^4",
     "@types/bcrypt": "^5.0.2",
     "@types/dotenv": "^8.2.3",
     "@types/express": "^5.0.2",
@@ -37,11 +38,11 @@
     "prisma": "^6.8.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "wavesurfer.js": "^7.9.5",
-    "@tailwindcss/postcss": "^4"
+    "wavesurfer.js": "^7.9.5"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
+    "@playwright/test": "^1.53.2",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
@@ -56,7 +57,8 @@
     "supertest": "^7.1.1",
     "tailwindcss": "^4",
     "ts-jest": "^29.3.4",
-    "@playwright/test": "^1.53.2",
-    "typescript": "^5"
+    "typescript": "^5",
+    "video.js": "^7.21.7",
+    "videojs-markers": "^1.0.1"
   }
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -60,7 +60,7 @@ model Project {
   owner      User     @relation("UserProjects", fields: [ownerId], references: [id])
   ownerId    Int
   status     ProjectStatus
-  songs      Song[]
+  media      Media[]
 }
 
 enum ProjectStatus {
@@ -69,20 +69,27 @@ enum ProjectStatus {
   archived
 }
 
-model Song {
+enum MediaType {
+  audio
+  video
+  image
+}
+
+model Media {
   id         Int      @id @default(autoincrement())
   project    Project  @relation(fields: [projectId], references: [id])
   projectId  Int
   title      String
   filePath   String
+  type       MediaType
   uploadDate DateTime @default(now())
   comments   Comment[]
 }
 
 model Comment {
   id        Int      @id @default(autoincrement())
-  song      Song     @relation(fields: [songId], references: [id])
-  songId    Int
+  media     Media    @relation(fields: [mediaId], references: [id])
+  mediaId   Int
   user      User     @relation(fields: [userId], references: [id])
   userId    Int
   text      String

--- a/src/app/api/project/[id]/media/[mediaId]/comment/route.ts
+++ b/src/app/api/project/[id]/media/[mediaId]/comment/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { PrismaClient } from '@/generated/prisma';
+import { requireSession } from '../../../../../auth/requireSession';
+
+const prisma = new PrismaClient();
+
+/**
+ * Get all comments for media
+ * @param req - The request object
+ * @param params - The parameters object
+ * @returns A response object
+ */
+export async function GET(req: NextRequest, { params }: { params: Promise<{ mediaId: string }> }) {
+  await requireSession(req);
+  try {
+    const { mediaId: mediaIdStr } = await params;
+    const mediaId = parseInt(mediaIdStr, 10);
+    if (isNaN(mediaId)) {
+      return NextResponse.json({ error: 'Invalid media id' }, { status: 400 });
+    }
+    const comments = await prisma.comment.findMany({
+      where: { mediaId },
+      orderBy: { createdAt: 'asc' },
+      include: { user: { select: { username: true } } },
+    });
+    return NextResponse.json(comments);
+  } catch (error) {
+    return NextResponse.json({ error: 'Failed to fetch comments', details: error instanceof Error ? error.message : error }, { status: 500 });
+  }
+}
+
+/**
+ * Add a comment to media
+ * @param req - The request object
+ * @param params - The parameters object
+ * @returns A response object
+ */
+export async function POST(req: NextRequest, { params }: { params: Promise<{ mediaId: string }> }) {
+  const session = await requireSession(req);
+  try {
+    const { mediaId: mediaIdStr } = await params;
+    const mediaId = parseInt(mediaIdStr, 10);
+    if (isNaN(mediaId)) {
+      return NextResponse.json({ error: 'Invalid media id' }, { status: 400 });
+    }
+    const body = await req.json();
+    const { text, time } = body;
+    if (!text || typeof text !== 'string') {
+      return NextResponse.json({ error: 'Missing or invalid comment text' }, { status: 400 });
+    }
+    const comment = await prisma.comment.create({
+      data: {
+        mediaId,
+        userId: session.userId,
+        text,
+        time: typeof time === 'number' ? time : undefined,
+      },
+      include: { user: { select: { username: true } } },
+    });
+    return NextResponse.json(comment, { status: 201 });
+  } catch (error) {
+    return NextResponse.json({ error: 'Failed to add comment', details: error instanceof Error ? error.message : error }, { status: 500 });
+  }
+} 

--- a/src/app/api/project/[id]/media/[mediaId]/route.ts
+++ b/src/app/api/project/[id]/media/[mediaId]/route.ts
@@ -1,0 +1,70 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { PrismaClient } from '@/generated/prisma';
+import { requireSession } from '../../../../auth/requireSession';
+
+const prisma = new PrismaClient();
+
+/**
+ * Get a single media item by id and projectId
+*/
+export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string, mediaId: string }> }) {
+  try {
+    const { id, mediaId } = await params;
+    const projectId = parseInt(id, 10);
+    const mediaIdNum = parseInt(mediaId, 10);
+    if (isNaN(projectId) || isNaN(mediaIdNum)) {
+      return NextResponse.json({ error: 'Invalid project or media id' }, { status: 400 });
+    }
+    const media = await prisma.media.findUnique({ where: { id: mediaIdNum } });
+    if (!media || media.projectId !== projectId) {
+      return NextResponse.json({ error: 'Media not found in project' }, { status: 404 });
+    }
+    return NextResponse.json(media);
+  } catch (error) {
+    return NextResponse.json({ error: 'Failed to fetch media', details: error instanceof Error ? error.message : error }, { status: 500 });
+  }
+}
+
+/**
+ * Delete a media item and all its comments
+ * @param req - The request object
+ * @param params - The parameters object
+ * @returns A response object
+ */
+export async function DELETE(req: NextRequest, { params }: { params: Promise<{ id: string, mediaId: string }> }) {
+  await requireSession(req);
+  try {
+    const { id, mediaId } = await params;
+    const projectId = parseInt(id, 10);
+    const mediaIdNum = parseInt(mediaId, 10);
+    if (isNaN(projectId) || isNaN(mediaIdNum)) {
+      return NextResponse.json({ error: 'Invalid project or media id' }, { status: 400 });
+    }
+    // Find the media
+    const media = await prisma.media.findUnique({ where: { id: mediaIdNum } });
+    if (!media || media.projectId !== projectId) {
+      return NextResponse.json({ error: 'Media not found in project' }, { status: 404 });
+    }
+    // Delete all comments for the media
+    await prisma.comment.deleteMany({ where: { mediaId: mediaIdNum } });
+    // Delete the media record
+    await prisma.media.delete({ where: { id: mediaIdNum } });
+    // Delete the audio file and waveform via audio microservice
+    if (media.filePath) {
+      const audioServiceUrl = process.env.AUDIO_SERVICE_URL || 'http://localhost:4001';
+      try {
+        await fetch(`${audioServiceUrl}/delete-media`, {
+          method: 'DELETE',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ fileName: media.filePath }),
+        });
+      } catch (err) {
+        // Log and continue
+        console.error('Failed to delete media file via audio service', media.filePath, err);
+      }
+    }
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    return NextResponse.json({ error: 'Failed to delete media', details: error instanceof Error ? error.message : error }, { status: 500 });
+  }
+} 

--- a/src/app/api/project/[id]/media/[mediaId]/signed-url/route.ts
+++ b/src/app/api/project/[id]/media/[mediaId]/signed-url/route.ts
@@ -1,0 +1,20 @@
+import { PrismaClient } from '@/generated/prisma';
+import { NextRequest, NextResponse } from 'next/server';
+import { signJwt } from '@/lib/jwt';
+
+const prisma = new PrismaClient();
+const DAYS = parseInt(process.env.AUDIO_LINK_EXPIRY_DAYS || '100', 10);
+
+export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string; songId: string }> }) {
+  const { songId } = await params;
+  const song = await prisma.song.findUnique({ where: { id: parseInt(songId, 10) } });
+  if (!song) {
+    return NextResponse.json({ error: 'Song not found' }, { status: 404 });
+  }
+  const token = signJwt({ file: song.filePath, type: 'file' }, DAYS * 24 * 60 * 60);
+  const base = req.nextUrl.origin + `/api/project/${song.projectId}/song`;
+  return NextResponse.json({
+    audioUrl: `${base}/audio?token=${token}`,
+    waveformUrl: `${base}/waveform?token=${token}`,
+  });
+}

--- a/src/app/api/project/[id]/media/route.ts
+++ b/src/app/api/project/[id]/media/route.ts
@@ -1,0 +1,163 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { PrismaClient } from '@/generated/prisma';
+import fetch from 'node-fetch';
+import FormData from 'form-data';
+import { requireSession } from '../../../auth/requireSession';
+
+const prisma = new PrismaClient();
+
+/**
+ * Get all media items for a project
+ * @param req - The request object
+ * @param params - The parameters object
+ * @returns A response object
+ */
+export async function GET(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const url = new URL(req.url);
+  const audioServiceUrl = process.env.AUDIO_SERVICE_URL || 'http://localhost:4001';
+  // If requesting a file or waveform, proxy to audio service
+  if (url.pathname.endsWith('/audio') && req.nextUrl.searchParams.has('file')) {
+    const fileName = req.nextUrl.searchParams.get('file');
+    const fileRes = await fetch(`${audioServiceUrl}/files/${fileName}`);
+    if (!fileRes.ok) {
+      return new NextResponse('File not found', { status: 404 });
+    }
+    const headers = Object.fromEntries(fileRes.headers.entries());
+    // Stream the response body directly
+    // @ts-expect-error: Next.js Response supports ReadableStream in edge runtime
+    return new NextResponse(fileRes.body as ReadableStream<Uint8Array>, { status: 200, headers });
+  }
+  if (url.pathname.endsWith('/waveform') && req.nextUrl.searchParams.has('file')) {
+    const fileName = req.nextUrl.searchParams.get('file');
+    const fileRes = await fetch(`${audioServiceUrl}/files/${fileName}.dat`);
+    if (!fileRes.ok) {
+      return new NextResponse('Waveform not found', { status: 404 });
+    }
+    const headers = Object.fromEntries(fileRes.headers.entries());
+    // Stream the response body directly
+    // @ts-expect-error: Next.js Response supports ReadableStream in edge runtime
+    return new NextResponse(fileRes.body as ReadableStream<Uint8Array>, { status: 200, headers });
+  }
+  try {
+    const projectId = parseInt(id, 10);
+    if (isNaN(projectId)) {
+      return NextResponse.json({ error: 'Invalid project id' }, { status: 400 });
+    }
+    const media = await prisma.media.findMany({
+      where: { projectId },
+      orderBy: { uploadDate: 'desc' },
+    });
+    return NextResponse.json(media);
+  } catch (error) {
+    return NextResponse.json({ error: 'Failed to fetch media', details: error instanceof Error ? error.message : error }, { status: 500 });
+  }
+}
+
+/**
+ * Upload a media file to a project
+ * @param req - The request object
+ * @param params - The parameters object
+ * @returns A response object
+ */
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  await requireSession(req);
+  try {
+    const { id: idStr } = await params;
+    const formData = await req.formData();
+    const file = formData.get('file') as File | null;
+    let title = formData.get('title') as string | null;
+    const projectId = parseInt(idStr, 10);
+    if (!file || isNaN(projectId)) {
+      console.warn('[Media Upload] Missing file or invalid project id', { file, projectId });
+      return NextResponse.json({ error: 'Missing file or invalid project id', details: { file: !!file, projectId } }, { status: 400 });
+    }
+    // Convert web File to Node.js Buffer
+    const arrayBuffer = await file.arrayBuffer();
+    const buffer = Buffer.from(arrayBuffer);
+    const uploadForm = new FormData();
+    uploadForm.append('file', buffer, {
+      filename: file.name,
+      contentType: file.type || 'application/octet-stream',
+    });
+    const audioServiceUrl = process.env.AUDIO_SERVICE_URL || 'http://localhost:4001';
+    const uploadRes = await fetch(`${audioServiceUrl}/upload`, {
+      method: 'POST',
+      body: uploadForm as unknown as FormData,
+      headers: (uploadForm as unknown as { getHeaders?: () => Record<string, string> }).getHeaders ? (uploadForm as unknown as { getHeaders: () => Record<string, string> }).getHeaders() : {},
+    });
+    if (!uploadRes.ok) {
+      const err = await uploadRes.json().catch(() => ({}));
+      console.error('[Media Upload] Media service upload failed', err);
+      return NextResponse.json({ error: 'Media service upload failed', details: err.error || uploadRes.statusText }, { status: 500 });
+    }
+    const { fileName } = await uploadRes.json();
+    // Use file name (without extension) as title if not provided
+    if (!title) {
+      title = file.name.replace(/\.[^/.]+$/, '');
+    }
+    const extension = file.name.split('.').pop()?.toLowerCase() || '';
+    const type: 'audio' | 'video' | 'image' = ['mp3','wav'].includes(extension) ? 'audio' : ['mp4','mov','avi','h264','m4v'].includes(extension) ? 'video' : 'image';
+    try {
+      const media = await prisma.media.create({
+        data: {
+          projectId,
+          title,
+          filePath: fileName,
+          type,
+        },
+      });
+      return NextResponse.json(media, { status: 201 });
+    } catch (dbError: unknown) {
+      console.error('[Media Upload] DB error creating media', {
+        projectId,
+        title,
+        fileName,
+        dbError: dbError instanceof Error ? dbError.message : dbError,
+      });
+      let hint = undefined;
+      if (typeof dbError === 'object' && dbError !== null && 'code' in dbError && (dbError as { code?: string }).code === 'P2003') {
+        hint = 'Check that the project with id ' + projectId + ' exists in the database.';
+      }
+      return NextResponse.json({
+        error: 'Failed to create media in database',
+        details: dbError instanceof Error ? dbError.message : dbError,
+        projectId,
+        fileName,
+        hint,
+      }, { status: 500 });
+    }
+  } catch (error) {
+    console.error('[Media Upload] Unexpected error', error);
+    return NextResponse.json({ error: 'Failed to upload media', details: error instanceof Error ? error.message : error }, { status: 500 });
+  }
+}
+
+/**
+ * Delete all media for a project
+ * @param req - The request object
+ * @param params - The parameters object
+ * @returns A response object
+ */
+export async function DELETE(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  await requireSession(req);
+  try {
+    const { id: idStr } = await params;
+    const projectId = parseInt(idStr, 10);
+    if (isNaN(projectId)) {
+      return NextResponse.json({ error: 'Invalid project id' }, { status: 400 });
+    }
+    const items = await prisma.media.findMany({
+      where: { projectId },
+    });
+    if (items.length === 0) {
+      return NextResponse.json({ error: 'No media found for the project' }, { status: 404 });
+    }
+    await prisma.media.deleteMany({
+      where: { projectId },
+    });
+    return NextResponse.json({ message: 'All media deleted successfully' }, { status: 200 });
+  } catch (error) {
+    return NextResponse.json({ error: 'Failed to delete media', details: error instanceof Error ? error.message : error }, { status: 500 });
+  }
+}

--- a/src/app/project/[id]/MediaListItemComponent.tsx
+++ b/src/app/project/[id]/MediaListItemComponent.tsx
@@ -1,0 +1,371 @@
+import React, { useEffect, useRef, useState } from 'react';
+import WaveSurfer from 'wavesurfer.js';
+import Hover from 'wavesurfer.js/dist/plugins/hover.esm.js';
+import Regions from 'wavesurfer.js/dist/plugins/regions.esm.js';
+import Link from 'next/link';
+
+function formatTime(seconds: number) {
+  const m = Math.floor(seconds / 60);
+  const s = Math.floor(seconds % 60);
+  return `${m}:${s.toString().padStart(2, '0')}`;
+}
+
+function decodeDatFile(buffer: ArrayBuffer): number[] {
+  // .dat files from audiowaveform are 32-bit floats, little-endian
+  const floatArray = new Float32Array(buffer);
+  return Array.from(floatArray);
+}
+
+interface Comment {
+  id: number;
+  text: string;
+  time?: number;
+  user?: { username: string };
+  createdAt?: string;
+}
+
+interface Media {
+  type: "audio" | "video" | "image";
+  id: number;
+  projectId: number;
+  filePath: string;
+  title: string;
+  uploadDate: string;
+}
+
+interface RegionPlugin {
+  clear: () => void;
+  addRegion: (region: {
+    start: number;
+    end: number;
+    color: string;
+    drag: boolean;
+    resize: boolean;
+  }) => void;
+}
+
+interface MediaListItemComponentProps {
+  media: Media;
+  comments: Comment[];
+  onAddComment: (mediaId: number, text: string, time: number | null) => Promise<void>;
+  commentInput: string;
+  onCommentInputChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  commentLoading: boolean;
+  onDeleteMedia: (mediaId: number) => void;
+}
+
+export default function MediaListItemComponent({ media, comments, onAddComment, commentInput, onCommentInputChange, commentLoading, onDeleteMedia }: MediaListItemComponentProps) {
+  const waveformRef = useRef<HTMLDivElement>(null);
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+  const wavesurferRef = useRef<WaveSurfer | null>(null);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [peaks, setPeaks] = useState<(Float32Array | number[])[] | undefined>(undefined);
+  const [duration, setDuration] = useState<number | undefined>(undefined);
+  const [showConfirm, setShowConfirm] = useState(false);
+  const [showToast, setShowToast] = useState(false);
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
+
+  // Fetch the precomputed waveform for audio files
+  useEffect(() => {
+    if (media.type !== 'audio') return;
+    let isMounted = true;
+    async function fetchPeaks() {
+      try {
+        const res = await fetch(`/api/project/${media.projectId}/media/waveform?file=${encodeURIComponent(media.filePath)}`);
+        if (!res.ok) return;
+        const buffer = await res.arrayBuffer();
+        const decoded = decodeDatFile(buffer);
+        if (isMounted) {
+          setPeaks([decoded]);
+        }
+      } catch {}
+    }
+    fetchPeaks();
+    return () => { isMounted = false; };
+  }, [media.filePath, media.projectId, media.type]);
+
+  // Setup wavesurfer with precomputed peaks
+  useEffect(() => {
+    if (media.type !== 'audio' || !waveformRef.current || !peaks) return;
+    // Use API proxy endpoint for audio file
+    const audioUrl = `/api/project/${media.projectId}/media/audio?file=${encodeURIComponent(media.filePath)}`;
+    const peaksOption = peaks;
+    const usedDuration = duration || 30;
+    const ws = WaveSurfer.create({
+      container: waveformRef.current,
+      waveColor: '#606070',
+      progressColor: '#202030',
+      cursorColor: '#0a0a0c',
+      height: 64,
+      minPxPerSec: 2,
+      url: audioUrl,
+      peaks: peaksOption,
+      duration: usedDuration,
+      plugins: [
+        Hover.create({
+          lineColor: '#f59e42',
+          labelBackground: '#fff',
+          labelColor: '#222',
+        }),
+        Regions.create(),
+      ]
+    });
+    wavesurferRef.current = ws;
+    ws.on('play', () => setIsPlaying(true));
+    ws.on('pause', () => setIsPlaying(false));
+    ws.on('finish', () => setIsPlaying(false));
+    ws.on('decode', (dur: number) => {
+      setDuration(dur);
+    });
+    return () => {
+      ws.destroy();
+      wavesurferRef.current = null;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [media.filePath, media.projectId, media.type, peaks]);
+
+  // Add comment markers as regions
+  useEffect(() => {
+    if (media.type !== 'audio') return;
+    const ws = wavesurferRef.current;
+    // Find the regions plugin instance from the active plugins array
+    const plugins = ws?.getActivePlugins?.();
+    const regions = plugins && Array.isArray(plugins)
+      ? plugins.find((p) => p && p.constructor && p.constructor.name === 'RegionsPlugin')
+      : undefined;
+    if (!ws || !regions) return;
+    (regions as unknown as RegionPlugin).clear();
+    (comments || []).forEach((comment) => {
+      if (comment.time !== undefined && comment.time !== null) {
+        (regions as unknown as RegionPlugin).addRegion({
+          start: comment.time,
+          end: comment.time + 0.1,
+          color: 'rgba(59,130,246,0.5)',
+          drag: false,
+          resize: false,
+        });
+      }
+    });
+  }, [comments]);
+
+  const handlePlayPause = () => {
+    if (media.type === 'audio' && wavesurferRef.current) {
+      wavesurferRef.current.playPause();
+    } else if (media.type === 'video' && videoRef.current) {
+      if (videoRef.current.paused) {
+        videoRef.current.play();
+        setIsPlaying(true);
+      } else {
+        videoRef.current.pause();
+        setIsPlaying(false);
+      }
+    }
+  };
+
+  const handleStop = () => {
+    if (media.type === 'audio' && wavesurferRef.current) {
+      wavesurferRef.current.stop();
+      setIsPlaying(false);
+    } else if (media.type === 'video' && videoRef.current) {
+      videoRef.current.pause();
+      videoRef.current.currentTime = 0;
+      setIsPlaying(false);
+    }
+  };
+
+  // When posting a comment, use the current cursor time
+  const handleAddCommentWithTime = async () => {
+    if (commentLoading) return;
+    let time = null;
+    if (media.type === 'audio' && wavesurferRef.current && typeof wavesurferRef.current.getCurrentTime === 'function') {
+      time = wavesurferRef.current.getCurrentTime();
+    } else if (media.type === 'video' && videoRef.current) {
+      time = videoRef.current.currentTime;
+    }
+    await onAddComment(media.id, commentInput, time);
+  };
+
+  // Handle Enter key for comment input
+  const handleCommentInputKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter' && !commentLoading) {
+      event.preventDefault();
+      handleAddCommentWithTime();
+    }
+  };
+
+  // Seek to a comment's time
+  const handleSeekToTime = (time?: number) => {
+    if (typeof time !== 'number') return;
+    if (media.type === 'audio' && wavesurferRef.current) {
+      wavesurferRef.current.setTime(time);
+    } else if (media.type === 'video' && videoRef.current) {
+      videoRef.current.currentTime = time;
+    }
+  };
+
+  const handleDownload = () => {
+    const url = `/api/project/${media.projectId}/media/audio?file=${encodeURIComponent(media.filePath)}`;
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = media.filePath;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  };
+
+  const handleShare = async () => {
+    const link = `${window.location.origin}/project/${media.projectId}/media/${media.id}`;
+    await navigator.clipboard.writeText(link);
+    setShowToast(true);
+    setTimeout(() => setShowToast(false), 1800);
+  };
+
+  const handleDelete = () => {
+    setShowConfirm(true);
+  };
+
+  const confirmDelete = () => {
+    setShowConfirm(false);
+    if (onDeleteMedia) onDeleteMedia(media.id);
+  };
+
+  const cancelDelete = () => {
+    setShowConfirm(false);
+  };
+
+  useEffect(() => {
+    fetch('/api/auth/session').then(res => setIsLoggedIn(res.ok));
+  }, []);
+
+  return (
+    <div className="bg-zinc-300 rounded shadow p-6 relative">
+      {/* Top right buttons */}
+      <div className="absolute top-2 right-2 flex gap-2 z-10">
+        <button
+          onClick={handleDownload}
+          className="p-1 rounded bg-indigo-500 hover:bg-indigo-700 text-white"
+          title={isLoggedIn ? 'Download media' : 'Sign in to download'}
+          disabled={!isLoggedIn}
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v2a2 2 0 002 2h12a2 2 0 002-2v-2M7 10l5 5m0 0l5-5m-5 5V4" /></svg>
+        </button>
+        <button
+          onClick={handleShare}
+          className="p-1 rounded bg-indigo-500 hover:bg-indigo-700 text-white"
+          title="Copy link to media details"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 7h2a2 2 0 012 2v8a2 2 0 01-2 2H7a2 2 0 01-2-2v-8a2 2 0 012-2h2" />
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15V3m0 0l-3.5 3.5M12 3l3.5 3.5" />
+          </svg>
+        </button>
+        <button
+          onClick={handleDelete}
+          className="p-1 rounded bg-red-500 hover:bg-red-700 text-white"
+          title={isLoggedIn ? 'Delete media' : 'Sign in to delete'}
+          disabled={!isLoggedIn}
+          aria-label="Delete Song"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5-4h4a1 1 0 011 1v2H9V4a1 1 0 011-1zm-7 4h18" />
+          </svg>
+        </button>
+      </div>
+      {/* Confirmation modal */}
+      {showConfirm && (
+        <div className="fixed inset-0 bg-black bg-opacity-30 flex items-center justify-center z-50">
+          <div className="bg-white p-6 rounded shadow w-full max-w-xs">
+            <h2 className="text-lg font-bold mb-4">Are you sure?</h2>
+            <div className="mb-4 text-gray-700">This will delete the media and all associated comments. This action cannot be undone.</div>
+            <div className="flex gap-2 justify-end">
+              <button onClick={cancelDelete} className="px-4 py-2 bg-gray-300 rounded">Cancel</button>
+              <button onClick={confirmDelete} className="px-4 py-2 bg-red-600 text-white rounded">Delete</button>
+            </div>
+          </div>
+        </div>
+      )}
+      {showToast && (
+        <div className="fixed top-4 left-1/2 transform -translate-x-1/2 bg-indigo-700 text-white px-4 py-2 rounded shadow-lg transition-all duration-300 animate-fade-in-out z-50">
+          Link copied to clipboard
+        </div>
+      )}
+      <h2 className="text-lg mb-2">
+        <Link href={`/project/${media.projectId}/media/${media.id}`} className="text-indigo-950 hover:underline">
+          {media.title}
+        </Link>
+      </h2>
+      <div className="text-gray-500 text-sm mb-2">Uploaded: {new Date(media.uploadDate).toLocaleString()}</div>
+      <div className="mb-2">
+        {media.type === 'audio' ? (
+          <div ref={waveformRef} className="w-full min-w-0" />
+        ) : (
+          <video ref={videoRef} className="w-full" controls>
+            <source src={`/api/project/${media.projectId}/media/audio?file=${encodeURIComponent(media.filePath)}`} />
+          </video>
+        )}
+      </div>
+
+      <div className="flex items-center gap-2 mb-4">
+        <button
+          onClick={handlePlayPause}
+          className="bg-indigo-600 text-white px-3 py-1 rounded hover:bg-indigo-700 flex items-center justify-center"
+          aria-label={isPlaying ? 'Pause' : 'Play'}
+        >
+          {isPlaying ? (
+            <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><rect x="6" y="5" width="4" height="14" rx="1"/><rect x="14" y="5" width="4" height="14" rx="1"/></svg>
+          ) : (
+            <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><polygon points="6,4 20,12 6,20" fill="currentColor"/></svg>
+          )}
+        </button>
+        <button
+          onClick={handleStop}
+          className="bg-gray-600 text-white px-3 py-1 rounded hover:bg-gray-700 flex items-center justify-center"
+          aria-label="Stop"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><rect x="6" y="6" width="12" height="12" rx="2" fill="currentColor"/></svg>
+        </button>
+      </div>
+      <div>
+        <h3 className="mb-2 text-sm">Comments</h3>
+        <ul className="mb-2">
+          {(comments || []).map((comment) => (
+            <li key={comment.id} className="border-b last:border-b-0 py-1 text-gray-700 flex justify-between items-center">
+              <span className='text-sm'>
+                {comment.time !== undefined && comment.time !== null && (
+                  <button
+                    type="button"
+                    className="bg-zinc-200 text-indigo-800 px-1 py-0.5 rounded text-xs font-mono mr-2 hover:bg-blue-200 focus:outline-none"
+                    onClick={() => handleSeekToTime(comment.time)}
+                  >
+                    
+                    {formatTime(comment.time)}
+                  </button>
+                )}
+                {comment.text}
+              </span>
+              <span className="text-xs text-gray-400 ml-2 text-right flex-1">{comment.user?.username}</span>
+              <span className="text-xs text-gray-400 ml-2">{comment.createdAt ? new Date(comment.createdAt).toLocaleString() : ''}</span>
+            </li>
+          ))}
+        </ul>
+        <div className="flex gap-2">
+          <input
+            type="text"
+            value={commentInput || ''}
+            onChange={e => onCommentInputChange(e)}
+            className="flex-1 border rounded px-2 py-1"
+            placeholder="Add a comment..."
+            onKeyDown={handleCommentInputKeyDown}
+          />
+          <button
+            onClick={handleAddCommentWithTime}
+            className="bg-indigo-600 text-white px-3 py-1 rounded hover:bg-indigo-700"
+            disabled={commentLoading}
+          >
+            {commentLoading ? 'Adding...' : 'Add'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+} 

--- a/src/app/project/[id]/media/[mediaId]/page.tsx
+++ b/src/app/project/[id]/media/[mediaId]/page.tsx
@@ -1,0 +1,386 @@
+"use client";
+import React, { useEffect, useRef, useState } from 'react';
+import { useRouter, useParams } from 'next/navigation';
+import WaveSurfer from 'wavesurfer.js';
+import Hover from 'wavesurfer.js/dist/plugins/hover.esm.js';
+import Regions from 'wavesurfer.js/dist/plugins/regions.esm.js';
+import BreadcrumbNavigationComponent from '../../../../components/BreadcrumbNavigationComponent';
+
+function formatTime(seconds: number) {
+  const m = Math.floor(seconds / 60);
+  const s = Math.floor(seconds % 60);
+  return `${m}:${s.toString().padStart(2, '0')}`;
+}
+
+function decodeDatFile(buffer: ArrayBuffer): number[] {
+  const floatArray = new Float32Array(buffer);
+  return Array.from(floatArray);
+}
+
+interface Comment {
+  id: number;
+  text: string;
+  time?: number;
+  user?: { username: string };
+  createdAt?: string;
+}
+
+interface Media {
+  type: "audio" | "video" | "image";
+  id: number;
+  projectId: number;
+  filePath: string;
+  title: string;
+  uploadDate: string;
+}
+
+interface RegionPlugin {
+  clear: () => void;
+  addRegion: (region: {
+    start: number;
+    end: number;
+    color: string;
+    drag: boolean;
+    resize: boolean;
+  }) => void;
+}
+
+export default function MediaPage() {
+  const params = useParams();
+  const projectId = Array.isArray(params.id) ? params.id[0] : params.id;
+  const mediaId = Array.isArray(params.mediaId) ? params.mediaId[0] : params.mediaId;
+
+  const [media, setMedia] = useState<Media | null>(null);
+  const [comments, setComments] = useState<Comment[]>([]);
+  const [commentInput, setCommentInput] = useState('');
+  const [commentLoading, setCommentLoading] = useState(false);
+  const [peaks, setPeaks] = useState<number[] | null>(null);
+  const [duration, setDuration] = useState<number | undefined>(undefined);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [showConfirm, setShowConfirm] = useState(false);
+  const [projectStatus, setProjectStatus] = useState<'open' | 'released' | 'archived'>('open');
+  const [projectName, setProjectName] = useState<string | undefined>(undefined);
+  const waveformRef = useRef<HTMLDivElement>(null);
+  const wavesurferRef = useRef<WaveSurfer | null>(null);
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+  const router = useRouter();
+  const [showToast, setShowToast] = useState(false);
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
+
+  // Fetch media, comments, and project status
+  useEffect(() => {
+    async function fetchData() {
+      const [mediaRes, commentsRes, projectRes] = await Promise.all([
+        fetch(`/api/project/${projectId}/media/${mediaId}`),
+        fetch(`/api/project/${projectId}/media/${mediaId}/comment`),
+        fetch(`/api/project/${projectId}`),
+      ]);
+      if (mediaRes.ok) setMedia(await mediaRes.json());
+      if (commentsRes.ok) setComments(await commentsRes.json());
+      if (projectRes.ok) {
+        const project = await projectRes.json();
+        setProjectStatus(project.status);
+        setProjectName(project.name);
+      }
+    }
+    fetchData();
+  }, [projectId, mediaId]);
+
+  // Fetch waveform peaks for audio
+  useEffect(() => {
+    if (!media || media.type !== 'audio') return;
+    let isMounted = true;
+    async function fetchPeaks() {
+      try {
+        if (!media) return;
+        const res = await fetch(`/api/project/${projectId}/media/waveform?file=${encodeURIComponent(media.filePath)}`);
+        if (!res.ok) return;
+        const buffer = await res.arrayBuffer();
+        const decoded = decodeDatFile(buffer);
+        if (isMounted) setPeaks(decoded);
+      } catch {}
+    }
+    fetchPeaks();
+    return () => { isMounted = false; };
+  }, [media, projectId]);
+
+  // Setup wavesurfer for audio
+  useEffect(() => {
+    if (media?.type !== 'audio' || !waveformRef.current || !peaks || !media) return;
+    const audioUrl = `/api/project/${projectId}/media/audio?file=${encodeURIComponent(media.filePath)}`;
+    let peaksOption: number[][];
+    if (Array.isArray(peaks[0])) {
+      // @ts-expect-error: peaks may be number[] or number[][], we handle both cases
+      peaksOption = peaks as number[][];
+    } else {
+      peaksOption = [peaks as unknown as number[]];
+    }
+    const usedDuration = duration || 30;
+    const ws = WaveSurfer.create({
+      container: waveformRef.current,
+      waveColor: '#606070',
+      progressColor: '#202030',
+      cursorColor: '#0a0a0c',
+      height: 64,
+      minPxPerSec: 2,
+      url: audioUrl,
+      peaks: peaksOption,
+      duration: usedDuration,
+      plugins: [
+        Hover.create({ lineColor: '#f59e42', labelBackground: '#fff', labelColor: '#222' }),
+        Regions.create(),
+      ],
+    });
+    wavesurferRef.current = ws;
+    ws.on('play', () => setIsPlaying(true));
+    ws.on('pause', () => setIsPlaying(false));
+    ws.on('finish', () => setIsPlaying(false));
+    ws.on('decode', (dur: number) => setDuration(dur));
+    // Add a passive wheel event listener to suppress Chrome warning
+    const el = waveformRef.current;
+    if (el) {
+      const noop = () => {};
+      el.addEventListener('wheel', noop, { passive: true });
+    }
+    return () => { ws.destroy(); wavesurferRef.current = null; };
+  }, [media, peaks, projectId, duration]);
+
+  // Add comment markers as regions
+  useEffect(() => {
+    const ws = wavesurferRef.current;
+    const plugins = ws?.getActivePlugins?.();
+    const regions = plugins && Array.isArray(plugins)
+      ? plugins.find((p) => p && p.constructor && p.constructor.name === 'RegionsPlugin')
+      : undefined;
+    if (!ws || !regions) return;
+    (regions as unknown as RegionPlugin).clear();
+    (comments || []).forEach((comment) => {
+      if (comment.time !== undefined && comment.time !== null) {
+        (regions as unknown as RegionPlugin).addRegion({
+          start: comment.time,
+          end: comment.time + 0.1,
+          color: 'rgba(59,130,246,0.5)',
+          drag: false,
+          resize: false,
+        });
+      }
+    });
+  }, [comments]);
+
+  const handlePlayPause = () => {
+    if (media?.type === 'audio' && wavesurferRef.current) {
+      wavesurferRef.current.playPause();
+    } else if (media?.type === 'video' && videoRef.current) {
+      if (videoRef.current.paused) { videoRef.current.play(); setIsPlaying(true); }
+      else { videoRef.current.pause(); setIsPlaying(false); }
+    }
+  };
+  const handleStop = () => {
+    if (media?.type === 'audio' && wavesurferRef.current) {
+      wavesurferRef.current.stop();
+      setIsPlaying(false);
+    } else if (media?.type === 'video' && videoRef.current) {
+      videoRef.current.pause();
+      videoRef.current.currentTime = 0;
+      setIsPlaying(false);
+    }
+  };
+  const handleDownload = () => {
+    if (!media) return;
+    const url = `/api/project/${projectId}/media/audio?file=${encodeURIComponent(media.filePath)}`;
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = media.filePath;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  };
+  const handleDelete = () => setShowConfirm(true);
+  const confirmDelete = async () => {
+    setShowConfirm(false);
+    await fetch(`/api/project/${projectId}/media/${mediaId}`, { method: 'DELETE' });
+    router.push(`/project/${projectId}`);
+  };
+  const cancelDelete = () => setShowConfirm(false);
+  const handleSeekToTime = (time?: number) => {
+    if (typeof time !== 'number') return;
+    if (media?.type === 'audio' && wavesurferRef.current) {
+      wavesurferRef.current.setTime(time);
+    } else if (media?.type === 'video' && videoRef.current) {
+      videoRef.current.currentTime = time;
+    }
+  };
+  const handleAddCommentWithTime = async () => {
+    if (commentLoading || !media) return;
+    let time = null;
+    if (media?.type === 'audio' && wavesurferRef.current && typeof wavesurferRef.current.getCurrentTime === 'function') {
+      time = wavesurferRef.current.getCurrentTime();
+    } else if (media?.type === 'video' && videoRef.current) {
+      time = videoRef.current.currentTime;
+    }
+    setCommentLoading(true);
+    await fetch(`/api/project/${projectId}/media/${mediaId}/comment`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text: commentInput, time }),
+    });
+    setCommentInput('');
+    setCommentLoading(false);
+    // Refresh comments
+    const commentsRes = await fetch(`/api/project/${projectId}/media/${mediaId}/comment`);
+    if (commentsRes.ok) setComments(await commentsRes.json());
+  };
+  const handleCommentInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' && !commentLoading) {
+      e.preventDefault();
+      handleAddCommentWithTime();
+    }
+  };
+  const handleShare = async () => {
+    const link = `${window.location.origin}/project/${projectId}/media/${mediaId}`;
+    await navigator.clipboard.writeText(link);
+    setShowToast(true);
+    setTimeout(() => setShowToast(false), 1800);
+  };
+
+  useEffect(() => {
+    fetch('/api/auth/session').then(res => setIsLoggedIn(res.ok));
+  }, []);
+
+  if (!media) return <div className="bg-zinc-400 min-h-screen w-full p-8">Loading...</div>;
+
+  return (
+    <div className="bg-zinc-400 min-h-screen w-full p-8">
+      <BreadcrumbNavigationComponent
+        projectId={projectId}
+        projectName={projectName}
+        mediaId={mediaId}
+        mediaTitle={media?.title}
+      />
+      <div className="bg-zinc-300 max-w-2xl mx-auto p-8 shadow-md relative">
+        {/* Top right buttons */}
+        <div className="absolute top-2 right-2 flex gap-2 z-10">
+          <button
+            onClick={handleDownload}
+            className="p-1 rounded bg-indigo-500 hover:bg-indigo-700 text-white"
+            title={isLoggedIn ? 'Download media' : 'Sign in to download'}
+            disabled={!isLoggedIn}
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v2a2 2 0 002 2h12a2 2 0 002-2v-2M7 10l5 5m0 0l5-5m-5 5V4" /></svg>
+          </button>
+          <button
+            onClick={handleShare}
+            className="p-1 rounded bg-indigo-500 hover:bg-indigo-700 text-white"
+            title="Copy link to media details"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 7h2a2 2 0 012 2v8a2 2 0 01-2 2H7a2 2 0 01-2-2v-8a2 2 0 012-2h2" />
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15V3m0 0l-3.5 3.5M12 3l3.5 3.5" />
+            </svg>
+          </button>
+          <button
+            onClick={projectStatus === 'open' ? handleDelete : undefined}
+            className={`p-1 rounded ${projectStatus === 'open' ? 'bg-red-500 hover:bg-red-700 text-white' : 'bg-gray-300 text-gray-400 cursor-not-allowed'}`}
+            title={projectStatus === 'open' ? 'Delete media' : 'Delete only available for open projects'}
+            aria-label="Delete Media"
+            disabled={projectStatus !== 'open'}
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5-4h4a1 1 0 011 1v2H9V4a1 1 0 011-1zm-7 4h18" />
+            </svg>
+          </button>
+        </div>
+        {showToast && (
+          <div className="fixed top-4 left-1/2 transform -translate-x-1/2 bg-indigo-700 text-white px-4 py-2 rounded shadow-lg transition-all duration-300 animate-fade-in-out z-50">
+            Link copied to clipboard
+          </div>
+        )}
+        <h1 className="text-2xl mb-2">{media.title}</h1>
+        <div className="text-gray-500 text-sm mb-2">Uploaded: {media.uploadDate ? new Date(media.uploadDate).toLocaleString() : ''}</div>
+        <div className="mb-4">
+          {media.type === 'audio' ? (
+            <div ref={waveformRef} className="w-full min-w-0" />
+          ) : (
+            <video ref={videoRef} className="w-full" controls>
+              <source src={`/api/project/${projectId}/media/audio?file=${encodeURIComponent(media.filePath)}`} />
+            </video>
+          )}
+        </div>
+        <div className="flex items-center gap-2 mb-4">
+          <button
+            onClick={handlePlayPause}
+            className="bg-indigo-600 text-white px-3 py-1 rounded hover:bg-indigo-700 flex items-center justify-center"
+            aria-label={isPlaying ? 'Pause' : 'Play'}
+          >
+            {isPlaying ? (
+              <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><rect x="6" y="5" width="4" height="14" rx="1"/><rect x="14" y="5" width="4" height="14" rx="1"/></svg>
+            ) : (
+              <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><polygon points="6,4 20,12 6,20" fill="currentColor"/></svg>
+            )}
+          </button>
+          <button
+            onClick={handleStop}
+            className="bg-gray-600 text-white px-3 py-1 rounded hover:bg-gray-700 flex items-center justify-center"
+            aria-label="Stop"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><rect x="6" y="6" width="12" height="12" rx="2" fill="currentColor"/></svg>
+          </button>
+        </div>
+        {/* Confirmation modal */}
+        {showConfirm && (
+          <div className="fixed inset-0 bg-black bg-opacity-30 flex items-center justify-center z-50">
+            <div className="bg-white p-6 rounded shadow w-full max-w-xs">
+              <h2 className="text-lg font-bold mb-4">Are you sure?</h2>
+              <div className="mb-4 text-gray-700">This will delete the media and all associated comments. This action cannot be undone.</div>
+              <div className="flex gap-2 justify-end">
+                <button onClick={cancelDelete} className="px-4 py-2 bg-gray-300 rounded">Cancel</button>
+                <button onClick={confirmDelete} className="px-4 py-2 bg-red-600 text-white rounded">Delete</button>
+              </div>
+            </div>
+          </div>
+        )}
+        <div>
+          <h3 className="mb-2 text-sm">Comments</h3>
+          <ul className="mb-2">
+            {(comments || []).map((comment) => (
+              <li key={comment.id} className="border-b last:border-b-0 py-1 text-gray-700 flex justify-between items-center">
+                <span className='text-sm'>
+                  {comment.time !== undefined && comment.time !== null && (
+                    <button
+                      type="button"
+                      className="bg-zinc-200 text-indigo-800 px-1 py-0.5 rounded text-xs font-mono mr-2 hover:bg-blue-200 focus:outline-none"
+                      onClick={() => handleSeekToTime(comment.time)}
+                    >
+                      {formatTime(comment.time)}
+                    </button>
+                  )}
+                  {comment.text}
+                </span>
+                <span className="text-xs text-gray-400 ml-2">{comment.createdAt ? new Date(comment.createdAt).toLocaleString() : ''}</span>
+              </li>
+            ))}
+          </ul>
+          <div className="flex gap-2">
+            <input
+              type="text"
+              value={commentInput}
+              onChange={e => setCommentInput(e.target.value)}
+              onKeyDown={handleCommentInputKeyDown}
+              className="border rounded px-2 py-1 w-full"
+              placeholder={isLoggedIn ? 'Add a comment...' : 'Sign in to comment'}
+              disabled={!isLoggedIn || commentLoading}
+            />
+            <button
+              onClick={handleAddCommentWithTime}
+              className="ml-2 px-3 py-1 bg-indigo-600 text-white rounded disabled:bg-gray-400"
+              disabled={!isLoggedIn || commentLoading}
+              title={isLoggedIn ? 'Add comment' : 'Sign in to comment'}
+            >
+              {commentLoading ? 'Adding...' : 'Add'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+} 

--- a/tests/api/api.comment.test.ts
+++ b/tests/api/api.comment.test.ts
@@ -1,4 +1,4 @@
-import { GET, POST } from '../../src/app/api/project/[id]/song/[songId]/comment/route';
+import { GET, POST } from '../../src/app/api/project/[id]/media/[mediaId]/comment/route';
 
 // Mock PrismaClient to avoid real DB calls
 jest.mock('../../src/generated/prisma', () => {
@@ -6,14 +6,14 @@ jest.mock('../../src/generated/prisma', () => {
     PrismaClient: jest.fn().mockImplementation(() => ({
       comment: {
         findMany: jest.fn().mockImplementation(({ where }) =>
-          Promise.resolve(where.songId === 1 ? [
-            { id: 1, songId: 1, text: 'Test comment', createdAt: new Date().toISOString() },
+          Promise.resolve(where.mediaId === 1 ? [
+            { id: 1, mediaId: 1, text: 'Test comment', createdAt: new Date().toISOString() },
           ] : [])
         ),
         create: jest.fn().mockImplementation(({ data }) =>
           Promise.resolve({
             id: 2,
-            songId: data.songId,
+            mediaId: data.mediaId,
             text: data.text,
             createdAt: new Date().toISOString(),
           })
@@ -26,7 +26,7 @@ jest.mock('../../src/generated/prisma', () => {
 describe('Comment API', () => {
   it('GET returns comments for a song', async () => {
     const req = {} as any;
-    const params = Promise.resolve({ songId: '1' });
+    const params = Promise.resolve({ mediaId: '1' });
     const res = await GET(req, { params });
     expect(res.status).toBe(200);
     const data = await res.json();
@@ -34,33 +34,33 @@ describe('Comment API', () => {
     expect(data[0].text).toBe('Test comment');
   });
 
-  it('GET returns 400 for invalid songId', async () => {
+  it('GET returns 400 for invalid mediaId', async () => {
     const req = {} as any;
-    const params = Promise.resolve({ songId: 'abc' });
+    const params = Promise.resolve({ mediaId: 'abc' });
     const res = await GET(req, { params });
     expect(res.status).toBe(400);
   });
 
   it('POST adds a comment', async () => {
     const req = { json: async () => ({ text: 'New comment' }) } as any;
-    const params = Promise.resolve({ songId: '1' });
+    const params = Promise.resolve({ mediaId: '1' });
     const res = await POST(req, { params });
     expect(res.status).toBe(201);
     const data = await res.json();
     expect(data.text).toBe('New comment');
-    expect(data.songId).toBe(1);
+    expect(data.mediaId).toBe(1);
   });
 
-  it('POST returns 400 for invalid songId', async () => {
+  it('POST returns 400 for invalid mediaId', async () => {
     const req = { json: async () => ({ text: 'New comment' }) } as any;
-    const params = Promise.resolve({ songId: 'abc' });
+    const params = Promise.resolve({ mediaId: 'abc' });
     const res = await POST(req, { params });
     expect(res.status).toBe(400);
   });
 
   it('POST returns 400 for missing text', async () => {
     const req = { json: async () => ({}) } as any;
-    const params = Promise.resolve({ songId: '1' });
+    const params = Promise.resolve({ mediaId: '1' });
     const res = await POST(req, { params });
     expect(res.status).toBe(400);
   });

--- a/tests/api/api.song.test.ts
+++ b/tests/api/api.song.test.ts
@@ -1,4 +1,4 @@
-import { POST } from '../../src/app/api/project/[id]/song/route';
+import { POST } from '../../src/app/api/project/[id]/media/route';
 
 // Mock node-fetch to simulate audio microservice
 jest.mock('node-fetch', () => jest.fn());
@@ -16,7 +16,7 @@ jest.mock('form-data', () => {
 jest.mock('../../src/generated/prisma', () => {
   return {
     PrismaClient: jest.fn().mockImplementation(() => ({
-      song: {
+      media: {
         create: jest.fn().mockImplementation(({ data }) =>
           Promise.resolve({
             id: 123,
@@ -36,7 +36,7 @@ type MockFile = {
   arrayBuffer: () => Promise<ArrayBuffer>;
 };
 
-describe('POST /api/project/[id]/song (unit)', () => {
+describe('POST /api/project/[id]/media (unit)', () => {
   beforeEach(() => {
     ((fetch as any) as jest.Mock).mockReset();
   });
@@ -58,21 +58,21 @@ describe('POST /api/project/[id]/song (unit)', () => {
     } as any;
   }
 
-  it('should upload a song with file and projectId', async () => {
+  it('should upload a media with file and projectId', async () => {
     ((fetch as any) as jest.Mock).mockResolvedValue({
       ok: true,
-      json: async () => ({ fileName: '1710000000000_mysong.mp3' }),
+      json: async () => ({ fileName: '1710000000000_mymedia.mp3' }),
       statusText: 'OK',
     });
-    const file = mockFile('mysong.mp3', 'dummydata');
+    const file = mockFile('mymedia.mp3', 'dummydata');
     const req = { formData: async () => mockFormData(file) } as any;
     const params = Promise.resolve({ id: '1' });
     const res = await POST(req, { params });
     expect(res.status).toBe(201);
     const data = await res.json();
-    expect(data.title).toBe('mysong');
+    expect(data.title).toBe('mymedia');
     expect(data.projectId).toBe(1);
-    expect(data.filePath).toContain('mysong.mp3');
+    expect(data.filePath).toContain('mymedia.mp3');
   });
 
   it('should return 400 for missing file', async () => {

--- a/tests/ui/MediaListItemComponent.test.tsx
+++ b/tests/ui/MediaListItemComponent.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom";
-import SongListItemComponent from "../../src/app/project/[id]/SongListItemComponent";
+import MediaListItemComponent from "../../src/app/project/[id]/MediaListItemComponent";
 import { act } from "react";
 
 jest.mock("wavesurfer.js", () => {
@@ -41,11 +41,11 @@ beforeEach(() => {
   jest.clearAllMocks();
 });
 
-describe("SongListItemComponent", () => {
-  const mockSong = {
+describe("MediaListItemComponent", () => {
+  const mockMedia = {
     id: 1,
     projectId: 1,
-    title: "Test Song",
+    title: "Test Media",
     filePath: "test.mp3",
     uploadDate: new Date().toISOString(),
   };
@@ -71,14 +71,14 @@ describe("SongListItemComponent", () => {
   it("renders song title and upload date", async () => {
     await act(() => {
       render(
-        <SongListItemComponent
-          song={mockSong}
+        <MediaListItemComponent
+          media={mockMedia}
           comments={mockComments}
           onAddComment={mockOnAddComment}
           commentInput=""
           onCommentInputChange={mockOnCommentInputChange}
           commentLoading={false}
-          onDeleteSong={jest.fn()}
+          onDeleteMedia={jest.fn()}
         />
       );
     });
@@ -89,14 +89,14 @@ describe("SongListItemComponent", () => {
   it("renders comments", async () => {
     await act(() => {
       render(
-        <SongListItemComponent
-          song={mockSong}
+        <MediaListItemComponent
+          media={mockMedia}
           comments={mockComments}
           onAddComment={mockOnAddComment}
           commentInput=""
           onCommentInputChange={mockOnCommentInputChange}
           commentLoading={false}
-          onDeleteSong={jest.fn()}
+          onDeleteMedia={jest.fn()}
         />
       );
     });
@@ -117,14 +117,14 @@ describe("SongListItemComponent", () => {
     );
     await act(async () => {
       render(
-        <SongListItemComponent
-          song={mockSong}
+        <MediaListItemComponent
+          media={mockMedia}
           comments={mockComments}
           onAddComment={mockOnAddComment}
           commentInput=""
           onCommentInputChange={mockOnCommentInputChange}
           commentLoading={false}
-          onDeleteSong={jest.fn()}
+          onDeleteMedia={jest.fn()}
         />
       );
       let input: HTMLElement | null = null;
@@ -141,14 +141,14 @@ describe("SongListItemComponent", () => {
   it("calls onAddComment when Add button is clicked", async () => {
     await act(async () => {
       render(
-        <SongListItemComponent
-          song={mockSong}
+        <MediaListItemComponent
+          media={mockMedia}
           comments={mockComments}
           onAddComment={mockOnAddComment}
           commentInput="Test comment"
           onCommentInputChange={mockOnCommentInputChange}
           commentLoading={false}
-          onDeleteSong={jest.fn()}
+          onDeleteMedia={jest.fn()}
         />
       );
     });
@@ -160,18 +160,18 @@ describe("SongListItemComponent", () => {
   it("shows Delete button always, enabled only if projectStatus is archived", async () => {
     await act(async () => {
       render(
-        <SongListItemComponent
-          song={mockSong}
+        <MediaListItemComponent
+          media={mockMedia}
           comments={mockComments}
           onAddComment={jest.fn()}
           commentInput={""}
           onCommentInputChange={jest.fn()}
           commentLoading={false}
-          onDeleteSong={jest.fn()}
+          onDeleteMedia={jest.fn()}
         />
       );
     });
-    const btn2 = await screen.findByLabelText("Delete Song");
+    const btn2 = await screen.findByLabelText("Delete Media");
     expect(btn2).toBeInTheDocument();
     expect(btn2).not.toBeDisabled();
   });


### PR DESCRIPTION
## Summary
- enable video uploads via new Media model
- support audio/video in media microservice and API routes
- update frontend components and pages for unified media
- adjust tests for /media endpoints
- document new media workflow

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867676b33d4832096f5467c962775eb